### PR TITLE
fix FOUC during client rendering

### DIFF
--- a/packages/react/index.tsx
+++ b/packages/react/index.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 const isServer = typeof document === 'undefined';
-const supportsDSD = 'shadowRootMode' in HTMLTemplateElement.prototype;
+const supportsDSD =
+	!isServer && 'shadowRootMode' in HTMLTemplateElement.prototype;
 
 export default function ShadowRoot({
 	children,
@@ -18,7 +19,7 @@ export default function ShadowRoot({
 	}
 
 	// By the time React hydrates, the browser has already removed the template element
-	if (!isServer && supportsDSD) return null;
+	if (supportsDSD) return null;
 
 	// for SSR, use DSD template
 	return <template {...{ shadowrootmode: mode }}>{children}</template>;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@declarative-shadow-dom/react",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"type": "module",
 	"description": "React component to use declarative shadow DOM",
 	"repository": {


### PR DESCRIPTION
This fixes a nasty flash of unslotted content caused by rendering `null` during first client render.

The trick is to rely on the server snapshot from [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) to differentiate between hydration and first "real" client render. The `null` fallback is only rendered when hydrating.